### PR TITLE
[bug-fix] TimeFeatureEmbedding KeyError with detailed freq arg.

### DIFF
--- a/layers/Embed.py
+++ b/layers/Embed.py
@@ -97,9 +97,20 @@ class TimeFeatureEmbedding(nn.Module):
     def __init__(self, d_model, embed_type='timeF', freq='h'):
         super(TimeFeatureEmbedding, self).__init__()
 
-        freq_map = {'h': 4, 't': 5, 's': 6,
-                    'm': 1, 'a': 1, 'w': 2, 'd': 3, 'b': 3}
-        d_inp = freq_map[freq]
+        def freq_to_dim(freq):
+            while freq[0].isdigit():
+                freq = freq[1:]
+            freq = freq.lower()
+            if freq == "min":
+                freq = 't'
+            elif freq == "A":
+                freq = 'y'
+
+            freq_map = {'h': 4, 't': 5, 's': 6,
+                        'm': 1, 'a': 1, 'w': 2, 'd': 3, 'b': 3}
+            return freq_map[freq]
+
+        d_inp = freq_to_dim(freq)
         self.embed = nn.Linear(d_inp, d_model, bias=False)
 
     def forward(self, x):


### PR DESCRIPTION
Experiment script argument `freq` description says "you can also use more detailed freq like 15min or 3h", but when we set like `--freq 15min` and the model uses `DataEmbedding` or `TimeFeatureEmbedding` will raise a `KeyError` because original implement don't consider the detailed `freq`

This PR fixes this bug.  Please review. @wuhaixu2016 @GuoKaku 