### PR TITLE
[bug-fix] Values of args are not actual while printing in console.

### DIFF
--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -65,7 +65,7 @@ def data_provider(args, flag):
             shuffle=shuffle_flag,
             num_workers=args.num_workers,
             drop_last=drop_last,
-            collate_fn=lambda x: collate_fn(x, max_len=args.seq_len)
+            collate_fn=partial(collate_fn, max_len=args.seq_len)
         )
         return data_set, data_loader
     else:

--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -1,7 +1,8 @@
 from data_provider.data_loader import Dataset_ETT_hour, Dataset_ETT_minute, Dataset_Custom, Dataset_M4, PSMSegLoader, \
-    MSLSegLoader, SMAPSegLoader, SMDSegLoader, SWATSegLoader, UEAloader
+    MSLSegLoader, SMAPSegLoader, SMDSegLoader, SWATSegLoader, UEAloader, BacteriaLoader
 from data_provider.uea import collate_fn
 from torch.utils.data import DataLoader
+from functools import partial
 
 data_dict = {
     'ETTh1': Dataset_ETT_hour,
@@ -15,7 +16,8 @@ data_dict = {
     'SMAP': SMAPSegLoader,
     'SMD': SMDSegLoader,
     'SWAT': SWATSegLoader,
-    'UEA': UEAloader
+    'UEA': UEAloader,
+    'Bacteria': BacteriaLoader,
 }
 
 

--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -634,7 +634,7 @@ class UEAloader(Dataset):
         # pre_process
         normalizer = Normalizer()
         self.feature_df = normalizer.normalize(self.feature_df)
-        print(len(self.all_IDs))
+        print(f"{flag} set size: {len(self.all_IDs)}")
 
     def load_all(self, root_path, file_list=None, flag=None):
         """
@@ -698,6 +698,114 @@ class UEAloader(Dataset):
         # Replace NaN values
         grp = df.groupby(by=df.index)
         df = grp.transform(interpolate_missing)
+
+        return df, labels_df
+
+    def instance_norm(self, case):
+        if self.root_path.count('EthanolConcentration') > 0:  # special process for numerical stability
+            mean = case.mean(0, keepdim=True)
+            case = case - mean
+            stdev = torch.sqrt(torch.var(case, dim=1, keepdim=True, unbiased=False) + 1e-5)
+            case /= stdev
+            return case
+        else:
+            return case
+
+    def __getitem__(self, ind):
+        return self.instance_norm(torch.from_numpy(self.feature_df.loc[self.all_IDs[ind]].values)), \
+               torch.from_numpy(self.labels_df.loc[self.all_IDs[ind]].values)
+
+    def __len__(self):
+        return len(self.all_IDs)
+
+
+class BacteriaLoader(Dataset):
+    """
+    Dataset class for datasets included in:
+        Time Series Classification Archive (www.timeseriesclassification.com)
+    Argument:
+        limit_size: float in (0, 1) for debug
+    Attributes:
+        all_df: (num_samples * seq_len, num_columns) dataframe indexed by integer indices, with multiple rows corresponding to the same index (sample).
+            Each row is a time step; Each column contains either metadata (e.g. timestamp) or a feature.
+        feature_df: (num_samples * seq_len, feat_dim) dataframe; contains the subset of columns of `all_df` which correspond to selected features
+        feature_names: names of columns contained in `feature_df` (same as feature_df.columns)
+        all_IDs: (num_samples,) series of IDs contained in `all_df`/`feature_df` (same as all_df.index.unique() )
+        labels_df: (num_samples, num_labels) pd.DataFrame of label(s) for each sample
+        max_seq_len: maximum sequence (time series) length. If None, script argument `max_seq_len` will be used.
+            (Moreover, script argument overrides this attribute)
+    """
+
+    def __init__(self, root_path, file_list=None, limit_size=None, flag=None):
+        self.root_path = root_path
+        self.all_df, self.labels_df = self.load_all(root_path, file_list=file_list, flag=flag)
+        self.all_IDs = self.all_df.index.unique()  # all sample IDs (integer indices 0 ... num_samples-1)
+
+        if limit_size is not None:
+            if limit_size > 1:
+                limit_size = int(limit_size)
+            else:  # interpret as proportion if in (0, 1]
+                limit_size = int(limit_size * len(self.all_IDs))
+            self.all_IDs = self.all_IDs[:limit_size]
+            self.all_df = self.all_df.loc[self.all_IDs]
+
+        # use all features
+        self.feature_names = self.all_df.columns
+        self.feature_df = self.all_df
+
+        # pre_process
+        normalizer = Normalizer()
+        self.feature_df = normalizer.normalize(self.feature_df)
+        print(f"{flag} set size: {len(self.all_IDs)}")
+
+    def load_all(self, root_path, file_list=None, flag=None):
+        """
+        Loads datasets from csv files contained in `root_path` into a dataframe, optionally choosing from `pattern`
+        Args:
+            root_path: directory containing all individual .csv files
+            file_list: optionally, provide a list of file paths within `root_path` to consider.
+                Otherwise, entire `root_path` contents will be used.
+        Returns:
+            all_df: a single (possibly concatenated) dataframe with all data corresponding to specified files
+            labels_df: dataframe containing label(s) for each sample
+        """
+        # Select paths for training and evaluation
+        if file_list is None:
+            data_paths = glob.glob(os.path.join(root_path, '*'))  # list of all paths
+        else:
+            data_paths = [os.path.join(root_path, p) for p in file_list]
+        if len(data_paths) == 0:
+            raise Exception('No files found using: {}'.format(os.path.join(root_path, '*')))
+        if flag is not None:
+            data_paths = list(filter(lambda x: re.search(flag, x), data_paths))
+        input_paths = [p for p in data_paths if os.path.isfile(p) and p.endswith('.csv')]
+        input_path = [p for p in input_paths if "features" in p]
+        label_path = [p for p in input_paths if "labels" in p]
+        if len(input_path) + len(label_path) != 2:
+            pattern='.csv'
+            raise Exception("No .csv files found or too many files found using pattern: '{}'".format(pattern))
+
+        all_df, labels_df = self.load_from_two_files(input_path[0], label_path[0])  # a single file contains dataset
+
+        return all_df, labels_df
+
+    def load_from_two_files(self, input_path: str, label_path: str):
+        df = pd.read_csv(input_path)
+        labels = pd.read_csv(label_path)
+        labels = pd.Series(labels["label"], dtype="category")
+        self.class_names = labels.cat.categories
+        labels_df = pd.DataFrame(labels.cat.codes,
+                                 dtype=np.int8)  # int8-32 gives an error when using nn.CrossEntropyLoss
+
+        self.max_seq_len = df.shape[0]
+
+        # First create a (seq_len, feat_dim) dataframe for each sample, indexed by a single integer ("ID" of the sample)
+        # Then concatenate into a (num_samples * seq_len, feat_dim) dataframe, with multiple rows corresponding to the
+        # sample index (i.e. the same scheme as all datasets in this project)
+        df = df.T.stack().reset_index(level=1)
+        df.drop(columns=["level_1"], inplace=True)
+        df.rename(columns={0: "dim_0"}, inplace=True)
+        df.index = pd.to_numeric(df.index)
 
         return df, labels_df
 

--- a/run.py
+++ b/run.py
@@ -123,6 +123,7 @@ if __name__ == '__main__':
     if args.is_training:
         for ii in range(args.itr):
             # setting record of experiments
+            exp = Exp(args)  # set experiments
             setting = '{}_{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(
                 args.task_name,
                 args.model_id,
@@ -142,7 +143,6 @@ if __name__ == '__main__':
                 args.distil,
                 args.des, ii)
 
-            exp = Exp(args)  # set experiments
             print('>>>>>>>start training : {}>>>>>>>>>>>>>>>>>>>>>>>>>>'.format(setting))
             exp.train(setting)
 


### PR DESCRIPTION
I found that in **run.py** module the line
`exp = Exp(args)  # set experiments`
changes values of args. Thus, printing of args prior "exp = Exp(args)" leads to printing of invalid values, e.g. default value of seq. length instead of real length retrieved from actual data. Also it leads to creation of wrong folders for results and checkpoints.
A solution:
As an option: switching the sequence of couple of lines solves the problem.   