### PR TITLE
[bug-fix] Values of args are not actual while printing in console.

### DIFF
--- a/run.py
+++ b/run.py
@@ -123,6 +123,7 @@ if __name__ == '__main__':
     if args.is_training:
         for ii in range(args.itr):
             # setting record of experiments
+            exp = Exp(args)  # set experiments
             setting = '{}_{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(
                 args.task_name,
                 args.model_id,
@@ -142,7 +143,6 @@ if __name__ == '__main__':
                 args.distil,
                 args.des, ii)
 
-            exp = Exp(args)  # set experiments
             print('>>>>>>>start training : {}>>>>>>>>>>>>>>>>>>>>>>>>>>'.format(setting))
             exp.train(setting)
 


### PR DESCRIPTION
I found that in **run.py** module the line
`exp = Exp(args)  # set experiments`
changes values of args. Thus, printing of args prior "exp = Exp(args)" leads to printing of invalid values, e.g. default value of seq. length instead of real length retrieved from actual data. Also it leads to creation of wrong folders for results and checkpoints.
A solution:
As an option: switching the sequence of couple of lines solves the problem.   