### PR TITLE
correct the normalization in PatchTST

### DIFF
--- a/models/PatchTST.py
+++ b/models/PatchTST.py
@@ -4,6 +4,14 @@ from layers.Transformer_EncDec import Encoder, EncoderLayer
 from layers.SelfAttention_Family import FullAttention, AttentionLayer
 from layers.Embed import PatchEmbedding
 
+class Transpose(nn.Module):
+    def __init__(self, *dims, contiguous=False): 
+        super().__init__()
+        self.dims, self.contiguous = dims, contiguous
+    def forward(self, x):
+        if self.contiguous: return x.transpose(*self.dims).contiguous()
+        else: return x.transpose(*self.dims)
+
 
 class FlattenHead(nn.Module):
     def __init__(self, n_vars, nf, target_window, head_dropout=0):
@@ -53,7 +61,7 @@ class Model(nn.Module):
                     activation=configs.activation
                 ) for l in range(configs.e_layers)
             ],
-            norm_layer=torch.nn.LayerNorm(configs.d_model)
+            norm_layer=nn.Sequential(Transpose(1,2), nn.BatchNorm1d(configs.d_model), Transpose(1,2))
         )
 
         # Prediction Head


### PR DESCRIPTION
![image](https://github.com/thuml/Time-Series-Library/assets/50574059/57b53989-e211-4b1e-8fb1-613688d704ee)
According to the PatchTST paper and the [official code of PatchTST](https://github.com/yuqinie98/PatchTST/blob/main/PatchTST_supervised/models/PatchTST.py), BatchNorm should be used in PatchTST. However, LayerNorm is used for PatchTST in this repo by default. It may mislead users who use this repo to reproduce PatchTST. This pull request changes the normalization from LayerNorm to BatchNorm following the official code and original paper.