### PR TITLE
Update exp_long_term_forecasting.py

### DIFF
--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -241,8 +241,8 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                     pd = np.concatenate((input[0, :, -1], pred[0, :, -1]), axis=0)
                     visual(gt, pd, os.path.join(folder_path, str(i) + '.pdf'))
 
-        preds = np.array(preds)
-        trues = np.array(trues)
+        preds = np.concatenate(preds, axis=0)
+        trues = np.concatenate(trues, axis=0)
         print('test shape:', preds.shape, trues.shape)
         preds = preds.reshape(-1, preds.shape[-2], preds.shape[-1])
         trues = trues.reshape(-1, trues.shape[-2], trues.shape[-1])


### PR DESCRIPTION
Match previous updates in `data_factory.py, linea27`：drop_last=True ----> drop_last=False

Otherwise, errors will occur during the testing of long-term forecasting experiments:
`IndexError: tuple index out of range when saving the long-term prediction experiment results`