### PR TITLE
Fix Monthly split for M4 Comp

### DIFF
--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -340,7 +340,7 @@ class Dataset_M4(Dataset):
             dataset = M4Dataset.load(training=False, dataset_file=self.root_path)
         training_values = np.array(
             [v[~np.isnan(v)] for v in
-             dataset.values[dataset.groups == self.seasonal_patterns]])  # split different frequencies
+             dataset.values[dataset.groups == self.seasonal_patterns]], dtype="object")  # split different frequencies
         self.ids = np.array([i for i in dataset.ids[dataset.groups == self.seasonal_patterns]])
         self.timeseries = [ts for ts in training_values]
 


### PR DESCRIPTION
Due to a sample size missmatch we need to define the dtype explicitly.

```python

Exp_Short_Term_Forecast(args)._get_data("test")

```

works, but 

```python

Exp_Short_Term_Forecast(args)._get_data("train")

```

raises an exception