### PR TITLE
remove act and dropout for dlinear's classification

### DIFF
--- a/models/DLinear.py
+++ b/models/DLinear.py
@@ -49,8 +49,6 @@ class Model(nn.Module):
                 (1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
 
         if self.task_name == 'classification':
-            self.act = F.gelu
-            self.dropout = nn.Dropout(configs.dropout)
             self.projection = nn.Linear(
                 configs.enc_in * configs.seq_len, configs.num_class)
 


### PR DESCRIPTION
It seems that to change a forecasting model to a classification model, the approach is to add an activation function, a dropout layer, and a projection layer. However, for DLinear, it appears that we don't need the activation function and the dropout layer to maintain the "single layer" structure of DLinear. Therefore, I removed the activation function and the dropout layer in the `__init__` method for DLinear.