### PR TITLE
Fix data_factory.py which will shuffle test dataset for classification tasks

### DIFF
--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -23,7 +23,7 @@ def data_provider(args, flag):
     Data = data_dict[args.data]
     timeenc = 0 if args.embed != 'timeF' else 1
 
-    shuffle_flag = False if flag == 'test' else True
+    shuffle_flag = False if (flag == 'test' or flag == 'TEST') else True
     drop_last = False
     batch_size = args.batch_size
     freq = args.freq


### PR DESCRIPTION
Turn "shuffle_flag = False if flag == 'test' else True" into "shuffle_flag = False if (flag == 'test' or flag == 'TEST') else True" at data_factory.py since Flags in classification tasks are in uppercase.