### PR TITLE
#bugfix: Mamba model_dict quotation error

### DIFF
--- a/exp/exp_basic.py
+++ b/exp/exp_basic.py
@@ -38,7 +38,7 @@ class Exp_Basic(object):
         if args.model == 'Mamba':
             print('Please make sure you have successfully installed mamba_ssm')
             from models import Mamba
-            self.model_dict[Mamba] = Mamba
+            self.model_dict['Mamba'] = Mamba
 
         self.device = self._acquire_device()
         self.model = self._build_model().to(self.device)


### PR DESCRIPTION
A small quotation error is found in the Mamba experiment. `self.model_dict` should take in a string format input.