### PR TITLE
Enhanced visualization for multivariate columns

### DIFF
--- a/utils/tools.py
+++ b/utils/tools.py
@@ -78,15 +78,30 @@ class StandardScaler():
         return (data * self.std) + self.mean
 
 
-def visual(true, preds=None, name='./pic/test.pdf'):
+def visual(col_name, pred_len, true, preds=None, name='./pic/test.pdf'):
     """
-    Results visualization
+    Results visualization for all columns
     """
-    plt.figure()
-    plt.plot(true, label='GroundTruth', linewidth=2)
-    if preds is not None:
-        plt.plot(preds, label='Prediction', linewidth=2)
-    plt.legend()
+    plt.figure(figsize=(15, 10))
+    n_columns = len(col_name)
+    start_idx = len(true) - pred_len
+
+    for idx, col in enumerate(col_name):
+        plt.subplot(n_columns, 1, idx+1)
+        if len(true.shape) > 1:
+            plt.plot(true[:, idx], label='GroundTruth', linewidth=2)
+            if preds is not None:
+                plt.plot(range(start_idx, len(true)), preds[-pred_len:, idx], label='Prediction', linewidth=2)
+        else:
+            plt.plot(true, label='GroundTruth', linewidth=2, zorder=2)
+            if preds is not None:
+                plt.plot(range(start_idx, len(true)), preds[-pred_len:], label='Prediction', linewidth=2, zorder=1)
+
+        plt.legend()
+        plt.title(col)
+        plt.grid(True)
+    
+    plt.tight_layout()
     plt.savefig(name, bbox_inches='tight')
 
 


### PR DESCRIPTION
I tried to fix the visualizing and saving process for convenient purposes. 

__Previous__: 
- Multivariate predicted columns are not visualized but the last column
- Since the name of the column is not available in the result, User had to figure out which columns is visualized
- Metrics are calculated for the last column only from random samples, which makes it less practical
- The user had to choose various samples from saved npy files and could not know which one was used for initial visualization.

  
  

__Now__:
- Multivariate predicted columns are visualized naturally not to mention the case of univariate prediction.
- The column's name appears in the result pdf to make it easy to interpret.
- Metrics are calculated for each column and recorded for each when visualization. The text of 'mse, rmse, mae' appears for practical purposes instead of using dtw.
- The user can use `core_true.npy` and `core_pred.npy` to reproduce visualized result while  `pred.npy` and `true.npy` files are saved separately.
  
  


__Issue__: there might need a test for unexpected bugs because of this code updated
- `self.args.use_dtw` does not appear in the training process nor `metrics.npy`.  Namely, the code below is disconnected.

```
        if self.args.use_dtw:
            dtw_list = []
            manhattan_distance = lambda x, y: np.abs(x - y)
            for i in range(preds.shape[0]):
                x = preds[i].reshape(-1,1)
                y = trues[i].reshape(-1,1)
                if i % 100 == 0:
                    print("calculating dtw iter:", i)
                d, _, _, _ = accelerated_dtw(x, y, dist=manhattan_distance)
                dtw_list.append(d)
            dtw = np.array(dtw_list).mean()
        else:
            dtw = 'not calculated'
```

I have tried to preserve the original code and features as much as possible when I update except for this part. I honestly do not know how to handle this.

