### PR TITLE
fix: prevent in-place operations in TimesNet model to avoid potential side effects

### DIFF
--- a/models/TimesNet.py
+++ b/models/TimesNet.py
@@ -103,10 +103,10 @@ class Model(nn.Module):
     def forecast(self, x_enc, x_mark_enc, x_dec, x_mark_dec):
         # Normalization from Non-stationary Transformer
         means = x_enc.mean(1, keepdim=True).detach()
-        x_enc = x_enc - means
+        x_enc = x_enc.sub(means)
         stdev = torch.sqrt(
             torch.var(x_enc, dim=1, keepdim=True, unbiased=False) + 1e-5)
-        x_enc /= stdev
+        x_enc = x_enc.div(stdev)
 
         # embedding
         enc_out = self.enc_embedding(x_enc, x_mark_enc)  # [B,T,C]
@@ -119,24 +119,24 @@ class Model(nn.Module):
         dec_out = self.projection(enc_out)
 
         # De-Normalization from Non-stationary Transformer
-        dec_out = dec_out * \
+        dec_out = dec_out.mul(
                   (stdev[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
-        dec_out = dec_out + \
+                      1, self.pred_len + self.seq_len, 1)))
+        dec_out = dec_out.add(
                   (means[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
+                      1, self.pred_len + self.seq_len, 1)))
         return dec_out
 
     def imputation(self, x_enc, x_mark_enc, x_dec, x_mark_dec, mask):
         # Normalization from Non-stationary Transformer
         means = torch.sum(x_enc, dim=1) / torch.sum(mask == 1, dim=1)
         means = means.unsqueeze(1).detach()
-        x_enc = x_enc - means
+        x_enc = x_enc.sub(means)
         x_enc = x_enc.masked_fill(mask == 0, 0)
         stdev = torch.sqrt(torch.sum(x_enc * x_enc, dim=1) /
                            torch.sum(mask == 1, dim=1) + 1e-5)
         stdev = stdev.unsqueeze(1).detach()
-        x_enc /= stdev
+        x_enc = x_enc.div(stdev)
 
         # embedding
         enc_out = self.enc_embedding(x_enc, x_mark_enc)  # [B,T,C]
@@ -147,21 +147,21 @@ class Model(nn.Module):
         dec_out = self.projection(enc_out)
 
         # De-Normalization from Non-stationary Transformer
-        dec_out = dec_out * \
+        dec_out = dec_out.mul(
                   (stdev[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
-        dec_out = dec_out + \
+                      1, self.pred_len + self.seq_len, 1)))
+        dec_out = dec_out.add(
                   (means[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
+                      1, self.pred_len + self.seq_len, 1)))
         return dec_out
 
     def anomaly_detection(self, x_enc):
         # Normalization from Non-stationary Transformer
         means = x_enc.mean(1, keepdim=True).detach()
-        x_enc = x_enc - means
+        x_enc = x_enc.sub(means)
         stdev = torch.sqrt(
             torch.var(x_enc, dim=1, keepdim=True, unbiased=False) + 1e-5)
-        x_enc /= stdev
+        x_enc = x_enc.div(stdev)
 
         # embedding
         enc_out = self.enc_embedding(x_enc, None)  # [B,T,C]
@@ -172,12 +172,12 @@ class Model(nn.Module):
         dec_out = self.projection(enc_out)
 
         # De-Normalization from Non-stationary Transformer
-        dec_out = dec_out * \
+        dec_out = dec_out.mul(
                   (stdev[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
-        dec_out = dec_out + \
+                      1, self.pred_len + self.seq_len, 1)))
+        dec_out = dec_out.add(
                   (means[:, 0, :].unsqueeze(1).repeat(
-                      1, self.pred_len + self.seq_len, 1))
+                      1, self.pred_len + self.seq_len, 1)))
         return dec_out
 
     def classification(self, x_enc, x_mark_enc):


### PR DESCRIPTION
## Changes
This PR addresses potential side effects caused by in-place operations in the TimesNet model.

### Modifications
- Replaced in-place operators (e.g., `/=`, `+=`) with their non-in-place counterparts (e.g., `= x / y`, `= x + y`)
- Ensured all tensor operations create new objects instead of modifying existing ones
- Maintained the original mathematical operations while improving code safety

### Rationale
1. In-place operators (`/=`, `+=`, etc.) modify tensors directly, which can lead to unexpected side effects
2. Using non-in-place operations creates new objects, making the code behavior more predictable
3. This change prevents potential issues in model training and inference

### Files Changed
- `models/TimesNet.py`

### Additional Notes
These modifications follow defensive programming practices by avoiding in-place operations, making the code more robust and easier to debug.