### PR TITLE
[Bugfix] Use `.requires_grad` instead of `.require_grad` in embedding module

### DIFF
--- a/layers/Embed.py
+++ b/layers/Embed.py
@@ -10,7 +10,7 @@ class PositionalEmbedding(nn.Module):
         super(PositionalEmbedding, self).__init__()
         # Compute the positional encodings once in log space.
         pe = torch.zeros(max_len, d_model).float()
-        pe.require_grad = False
+        pe.requires_grad = False
 
         position = torch.arange(0, max_len).float().unsqueeze(1)
         div_term = (torch.arange(0, d_model, 2).float()
@@ -47,7 +47,7 @@ class FixedEmbedding(nn.Module):
         super(FixedEmbedding, self).__init__()
 
         w = torch.zeros(c_in, d_model).float()
-        w.require_grad = False
+        w.requires_grad = False
 
         position = torch.arange(0, c_in).float().unsqueeze(1)
         div_term = (torch.arange(0, d_model, 2).float()


### PR DESCRIPTION
This pull request fixes a bug / typo in `layers/Embed.py` on lines 13 and 50. 

Torch tensors do not have an attribute called `require_grad`, and therefore `pe.require_grad = False` and `w.require_grad = False` calls were resulting in the insertion of an additional `require_grad` attribute to the instantiated tensor, that did nothing.

The correct attribute to track gradients is Torch is called `requires_grad`, and in this PR both lines (13 and 50) are changed to reflect this.

The existing bug / typo is not expected to have affected any code behavior, as when a tensor is created using `torch.zeros`, it by default comes with `requires_grad` attribute set to `False` anyways. But for the sake of clarity and preventing any future confusion it is worthwhile to fix the bug anyways.