### PR TITLE
val criterion cal from cpu to gpu

### DIFF
--- a/exp/exp_anomaly_detection.py
+++ b/exp/exp_anomaly_detection.py
@@ -51,11 +51,11 @@ class Exp_Anomaly_Detection(Exp_Basic):
 
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, :, f_dim:]
-                pred = outputs.detach().cpu()
-                true = batch_x.detach().cpu()
+                pred = outputs.detach()
+                true = batch_x.detach()
 
                 loss = criterion(pred, true)
-                total_loss.append(loss)
+                total_loss.append(loss.item())
         total_loss = np.average(total_loss)
         self.model.train()
         return total_loss

--- a/exp/exp_classification.py
+++ b/exp/exp_classification.py
@@ -57,9 +57,9 @@ class Exp_Classification(Exp_Basic):
 
                 outputs = self.model(batch_x, padding_mask, None, None)
 
-                pred = outputs.detach().cpu()
-                loss = criterion(pred, label.long().squeeze().cpu())
-                total_loss.append(loss)
+                pred = outputs.detach()
+                loss = criterion(pred, label.long().squeeze())
+                total_loss.append(loss.item())
 
                 preds.append(outputs.detach())
                 trues.append(label)

--- a/exp/exp_imputation.py
+++ b/exp/exp_imputation.py
@@ -65,12 +65,12 @@ class Exp_Imputation(Exp_Basic):
                 batch_x = batch_x[:, :, f_dim:]
                 mask = mask[:, :, f_dim:]
 
-                pred = outputs.detach().cpu()
-                true = batch_x.detach().cpu()
-                mask = mask.detach().cpu()
+                pred = outputs.detach()
+                true = batch_x.detach()
+                mask = mask.detach()
 
                 loss = criterion(pred[mask == 0], true[mask == 0])
-                total_loss.append(loss)
+                total_loss.append(loss.item())
         total_loss = np.average(total_loss)
         self.model.train()
         return total_loss

--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -63,12 +63,12 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
 
-                pred = outputs.detach().cpu()
-                true = batch_y.detach().cpu()
+                pred = outputs.detach()
+                true = batch_y.detach()
 
                 loss = criterion(pred, true)
 
-                total_loss.append(loss)
+                total_loss.append(loss.item())
         total_loss = np.average(total_loss)
         self.model.train()
         return total_loss


### PR DESCRIPTION
对`exp_anomaly_detection`,`exp_classification`,`exp_imputation`,`exp_long_term_forecasting`，val函数中`criterion`从在cpu上计算改为在gpu上计算，解决[issue #752 ](https://github.com/thuml/Time-Series-Library/issues/752#issue-3191108332)