### PR TITLE
fix: update val_loss_min from np.Inf to np.inf for consistency

### DIFF
--- a/tutorial/TimesNet_tutorial.ipynb
+++ b/tutorial/TimesNet_tutorial.ipynb
@@ -712,7 +712,7 @@
     "        self.counter = 0 # now how many times loss not on decrease\n",
     "        self.best_score = None\n",
     "        self.early_stop = False\n",
-    "        self.val_loss_min = np.Inf\n",
+    "        self.val_loss_min = np.inf\n",
     "        self.delta = delta\n",
     "\n",
     "    def __call__(self, val_loss, model, path):\n",

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -36,7 +36,7 @@ class EarlyStopping:
         self.counter = 0
         self.best_score = None
         self.early_stop = False
-        self.val_loss_min = np.Inf
+        self.val_loss_min = np.inf
         self.delta = delta
 
     def __call__(self, val_loss, model, path):


### PR DESCRIPTION
Fix possible issue of `np.Inf` in higher `numpy` version `AttributeError: np.Inf was removed in the NumPy 2.0 release. Use np.inf instead.`

```
AttributeError                            Traceback (most recent call last)
Cell In[1], line 3
      1 import numpy as np
----> 3 a = np.Inf

File /lib/python3.12/site-packages/numpy/__init__.py:397, in __getattr__(attr)
    394     raise AttributeError(__former_attrs__[attr])
    396 if attr in __expired_attributes__:
--> 397     raise AttributeError(
    398         f"`np.{attr}` was removed in the NumPy 2.0 release. "
    399         f"{__expired_attributes__[attr]}"
    400     )
    402 if attr == "chararray":
    403     warnings.warn(
    404         "`np.chararray` is deprecated and will be removed from "
    405         "the main namespace in the future. Use an array with a string "
    406         "or bytes dtype instead.", DeprecationWarning, stacklevel=2)

AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.
```