### PR TITLE
Add HuggingFace dataset adapter

### DIFF
--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -16,7 +16,7 @@ from datasets import load_dataset
 from huggingface_hub import hf_hub_download
 warnings.filterwarnings('ignore')
 
-HUGGINGFACE_REPO = "lalababa/Time-Series-Library"
+HUGGINGFACE_REPO = "thuml/Time-Series-Library"
 
 class Dataset_ETT_hour(Dataset):
     def __init__(self, args, root_path, flag='train', size=None,

--- a/data_provider/m4.py
+++ b/data_provider/m4.py
@@ -32,7 +32,7 @@ import sys
 from urllib import request
 from huggingface_hub import hf_hub_download
 
-HUGGINGFACE_REPO = "lalababa/Time-Series-Library"
+HUGGINGFACE_REPO = "thuml/Time-Series-Library"
 
 def _ensure_m4_triplet(root_dir="./dataset/m4", repo_id=HUGGINGFACE_REPO):
     root_dir = os.path.abspath(root_dir)


### PR DESCRIPTION
This update adds a HuggingFace-compatible dataset adapter.
The loader will first try to locate the dataset from the local path;
if no local files are found, it will automatically download the dataset from HuggingFace.