### PR TITLE
Fix M4 dataset sequence length mismatch

### DIFF
--- a/data_provider/m4.py
+++ b/data_provider/m4.py
@@ -159,3 +159,30 @@ def load_m4_info() -> pd.DataFrame:
     :return: Pandas DataFrame of M4Info.
     """
     # return pd.read_csv(INFO_FILE_PATH)
+
+
+def pad_sequences(sequences, target_len, mode='edge'):
+    """
+    统一序列长度（填充或截断）
+    :param sequences: 原始序列列表（长度可能不同）
+    :param target_len: 目标长度
+    :param mode: 填充模式，'edge' 用最后一个值填充，'zero' 用0填充
+    :return: 长度统一的序列数组
+    """
+    padded = []
+    for seq in sequences:
+        seq_len = len(seq)
+        if seq_len < target_len:
+            # 填充到目标长度
+            pad_length = target_len - seq_len
+            if mode == 'edge':
+                # 用最后一个值填充（更适合时间序列）
+                padded_seq = np.pad(seq, (0, pad_length), mode='edge')
+            else:
+                # 用0填充
+                padded_seq = np.pad(seq, (0, pad_length), mode='constant', constant_values=0)
+        else:
+            # 截断到目标长度
+            padded_seq = seq[:target_len]
+        padded.append(padded_seq)
+    return np.array(padded)


### PR DESCRIPTION
## 问题描述
M4 数据集在加载时存在序列长度不一致的问题，导致readme训练与评测中第二个部分模型训练。
bash ./scripts/short_term_forecast/TimesNet_M4.sh
执行bug：
## 修改内容
1. 调整 `data_provider/m4.py` 中数据解析逻辑，统一序列长度处理方式。
2. 优化 {insert\_element\_0\_YGRhdGFfcHJvdmlkZXIvZGF0YV9sb2FkZXIucHlg} 中的滑窗截取逻辑，兼容 M4 数据集的长度特性。

## 验证方式
已通过 {insert\_element\_1\_YHNjcmlwdHMvc2hvcnRfdGVybV9mb3JlY2FzdC9UaW1lc05ldF9NNC5zaGA=} 脚本测试，可正常运行 M4 数据集的短期预测任务，无长度不匹配报错。